### PR TITLE
Refactor/indicator

### DIFF
--- a/src/pqam.js
+++ b/src/pqam.js
@@ -1486,10 +1486,10 @@ import './rastercoords.js'
       let assetCurrent =
           self.current.asset[assetID] || (self.current.asset[assetID]={})
 
-      stateName =
-        stateName || assetCurrent.stateName || (Object.keys(self.config.states)[0])
+      asset.stateName =
+        stateName || asset.stateName || (Object.keys(self.config.states)[0])
 
-      let stateDef = self.config.states[stateName]
+      let stateDef = self.config.states[asset.stateName]
 
       let assetProps = asset.ent
 
@@ -1533,7 +1533,6 @@ import './rastercoords.js'
         let ax = assetPoint[1]
         let ay = assetPoint[0]
         
-        assetCurrent.stateName = stateName
         let color = stateDef.color
       
         if(null == assetCurrent.indicator) {
@@ -2238,6 +2237,7 @@ import './rastercoords.js'
     infobox = null
     show = null
     label = null
+    stateName = null
     
     constructor(ent,ctx) {
       this.ent = ent

--- a/src/pqam.js
+++ b/src/pqam.js
@@ -1481,6 +1481,7 @@ import './rastercoords.js'
       // if(assetID == '1E82DD49-2F3F-5DA3-4EA9-AA3C61B56628') {
       //   console.log('showAsset', spec)
       // }
+      let asset = self.asset.map[assetID]
       
       let assetCurrent =
           self.current.asset[assetID] || (self.current.asset[assetID]={})
@@ -1490,7 +1491,6 @@ import './rastercoords.js'
 
       let stateDef = self.config.states[stateName]
 
-      let asset = self.asset.map[assetID]
       let assetProps = asset.ent
 
       try {

--- a/src/pqam.js
+++ b/src/pqam.js
@@ -1497,10 +1497,10 @@ import './rastercoords.js'
 
 
         // Ignore assets with invalid coords
-        if(null == assetProps || null == assetProps.xco || null == assetProps.yco) {
+        if(asset.hasInvalidCoords()) {
           return
         }
-      
+
         asset.infobox = infobox == null ? true : !!infobox
 
         assetCurrent.assetID = assetID
@@ -2233,6 +2233,8 @@ import './rastercoords.js'
   class Asset {
     ent = null
     ctx = null
+    xco = null
+    yco = null
     infobox = null
     show = null
     label = null
@@ -2241,6 +2243,15 @@ import './rastercoords.js'
     constructor(ent,ctx) {
       this.ent = ent
       this.ctx = ctx
+      this.xco = this.ent.xco
+      this.yco = this.ent.yco
+    }
+
+    hasInvalidCoords() {
+      if(null == this.xco || null == this.yco) {
+        return true
+      }
+      return false
     }
 
     buildIndicator(args) {

--- a/src/pqam.js
+++ b/src/pqam.js
@@ -1489,8 +1489,6 @@ import './rastercoords.js'
       asset.stateName =
         stateName || asset.stateName || (Object.keys(self.config.states)[0])
 
-      let stateDef = self.config.states[asset.stateName]
-
       let assetProps = asset.ent
 
       try {
@@ -1533,6 +1531,7 @@ import './rastercoords.js'
         let ax = assetPoint[1]
         let ay = assetPoint[0]
         
+        let stateDef = self.config.states[asset.stateName]
         let color = stateDef.color
       
         if(null == assetCurrent.indicator) {


### PR DESCRIPTION
This PR:

Replace references to `current.current.asset[assetID]` to `self.asset.map[assetID]`.
Reason : After adding a new asset object to `showAsset()`, this  same function started handling a different asset  object compared to others functions.
Between the times `showAsset()` is called, `current.current.asset[assetID]` has its state changed, while `self.asset.map[assetID]` stills the same, preventing  `showAsset()` to work correctly as it relies on `self.asset.map[assetID]` now.

This PR also remove references to `currentAsset` from `showAsset()`